### PR TITLE
Fixed duplicates bug

### DIFF
--- a/server/db_live_parser.py
+++ b/server/db_live_parser.py
@@ -191,7 +191,7 @@ while True and retry_count < 10:
                 else:
                     session.add(DynamicStationsLive(**data))
 
-                if not session.query(DynamicStations).filter(DynamicStations.Number == data['Number'], DynamicStations.LastUpdate == data['RequestTime']).first():
+                if not session.query(DynamicStations).filter(DynamicStations.Number == data['Number'], DynamicStations.RequestTime == data['RequestTime']).first():
                     session.add(DynamicStations(**data))
                 else:
                     logging.info(f"Avoiding duplicates!")


### PR DESCRIPTION
Just found a bug in the `db_live_parser.py` script that I introduced when adding the `RequestTime` column to the tables.

This PR should solve the problem as I was not comparing the right columns when checking if the data was already in the table.