### PR TITLE
Chart improvements and app.py fixes

### DIFF
--- a/dbikes/flaskapp/app.py
+++ b/dbikes/flaskapp/app.py
@@ -26,6 +26,7 @@ def plan():
 
 @app.route("/about_us")
 def about_us():
+    return render_template("about_us.html")
 
 
 @app.route("/map")
@@ -51,7 +52,6 @@ def prediction():
 #function that gets the station number from the html webpage and saves it to the session
 @app.route("/varSender",methods=["GET","POST"])
 def varGet():
-    print("IT FUCKIN GOT THIS FAR")
     if request.method == "POST":
         data=request.get_json()
         session["station_number"] = str(data["number"])
@@ -64,7 +64,7 @@ def buttonFunction():
     number = session.get("station_number",None)
     engine = create_engine(f"mysql+mysqlconnector://{DB_NAME}:{DB_PASS}@{DB_HOST}/dbikes_main", echo=True)
     dateDiff = (datetime.datetime.now() - datetime.timedelta(7)).timestamp()
-    df = pd.read_sql_query(f"SELECT DISTINCT Number, AvailableBikeStands, AvailableBikes, LastUpdate from dynamic_stations WHERE LastUpdate > {dateDiff} AND Number = {number}", engine)
+    df = pd.read_sql_query(f"SELECT DISTINCT Number, AvailableBikeStands, AvailableBikes, LastUpdate from dynamic_stations WHERE LastUpdate > {dateDiff} AND Number = {number} GROUP BY DAY(dynamic_stations.LastUpdate)", engine)
     return df.to_json(orient='records')
 
 
@@ -74,7 +74,7 @@ def buttonFunctionDay():
     number = session.get("station_number",None)
     engine = create_engine(f"mysql+mysqlconnector://{DB_NAME}:{DB_PASS}@{DB_HOST}/dbikes_main", echo=True)
     dateDiff = (datetime.datetime.now() - datetime.timedelta(1)).timestamp()
-    df = pd.read_sql_query(f"SELECT DISTINCT Number, AvailableBikeStands, AvailableBikes, LastUpdate from dynamic_stations WHERE LastUpdate > {dateDiff} AND Number = {number}", engine)
+    df = pd.read_sql_query(f"SELECT DISTINCT Number, AvailableBikeStands, AvailableBikes, LastUpdate from dynamic_stations WHERE LastUpdate > {dateDiff} AND Number = {number} GROUP BY HOUR (dynamic_stations.LastUpdate)", engine)
     return df.to_json(orient='records')
 
 

--- a/dbikes/flaskapp/templates/map.html
+++ b/dbikes/flaskapp/templates/map.html
@@ -128,6 +128,47 @@ function varSender(number){
     event.preventDefault();
             
         }
+
+        function dayConverter(day_number){
+            var days={
+                0 : "Sunday",
+                1 : "Monday",
+                2 : "Tuesday",
+                3 : "Wednesday",
+                4 : "Thursday",
+                5 : "Friday",
+                6 : "Saturday",
+                
+            };
+            return days[day_number];
+            
+            /*
+            switch(day_number){
+                case 0:
+                    return "Sunday";
+                    break;
+                case 1:
+                    return "Monday";
+                    break;
+                case 2:
+                    return "Tuesday";
+                    break;
+                case 3:
+                    return "Wednesday";
+                    break;
+                case 4:
+                    return "Thursday";
+                    break;
+                case 5:
+                    return "Friday";
+                    break;
+                case 6:
+                    return "Saturday";
+                    break;
+            }
+            */
+            
+        }
         
             // Button functionality
                 async function buttonPrediction(station_number,station_name){
@@ -147,14 +188,14 @@ function varSender(number){
                     
                     // Assign each variable in the json files to its appropriate list
                     for(i in jsonweek){
-                        weekTimes.push(jsonweek[i].LastUpdate);
+                        weekTimes.push(dayConverter(new Date(jsonweek[i].LastUpdate).getDay()));
                         weekAvailBikes.push(jsonweek[i].AvailableBikes);
                         weekAvailStands.push(jsonweek[i].AvailableBikeStands);
                         
                     }
                     
                     for(i in jsonday){
-                        daytimes.push(jsonday[i].LastUpdate);
+                        daytimes.push(String(new Date(jsonday[i].LastUpdate).getHours()) + ":00");
                         dayAvailBike.push(jsonday[i].AvailableBikes);
                         dayAvailStands.push(jsonday[i].AvailableBikeStands);             
                     }
@@ -284,7 +325,7 @@ const bikered ={
         
     </script>
     <script
-	    src="https://maps.googleapis.com/maps/api/js?key=YourAPIKey&callback=initMap&libraries=&v=weekly"
+	    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDQ60ZznWkdrHJc7wnCJqx67J_pjGNUebE&callback=initMap&libraries=&v=weekly"
       async
     ></script>
 </body>


### PR DESCRIPTION
Improved the charts so that the time is now measured in hours for the daily and in days for the weekly. This is achieved through using groupBy in the app.py, also restored the about us return render and removed some colourful language