### PR TITLE
Change prediction to support more browsers

### DIFF
--- a/dbikes/flaskapp/app.py
+++ b/dbikes/flaskapp/app.py
@@ -168,6 +168,7 @@ def predGet():
         print(data)
         session["station_number"] = str(data["number"])
         session["date"]=str(data["date"])
+        session["time"]=str(data["time"])
         # after setting the variables thi is then routed to the predSend function
         return redirect(url_for("predSend"))
 
@@ -181,16 +182,17 @@ def predSend():
     # retrieves the session variables (station number and the date for the prediction
     number= session.get("station_number",None)
     date=session.get("date",None)
-    # format for reformatting the retrieved date for the prediction model
-    p = '%Y-%m-%dT%H:%M'
+    time=session.get("time",None)
+    print("Testing",date,time)
+    print(type(date))
+
+    date=datetime.strptime(date,'%Y-%m-%d')
+
     # set weekday to True
     weekday = True
-    # format the date so it works with the prediction
-    date =datetime.strptime(date,p)
-    # remove the minutes
-    date=date.replace(minute=0)
+
     # retrieve the hour (hour is one of the variables used in the prediction
-    hour=date.hour
+    hour=int(time.split(":")[0])
     # set the weeday to false if the prediction date day is saturday or sunday
     if date.day > 5:
         weekday=False

--- a/dbikes/flaskapp/static/js/map.js
+++ b/dbikes/flaskapp/static/js/map.js
@@ -13,14 +13,12 @@ google.charts.setOnLoadCallback(drawChart);
 
 let map;
 
+
+
 //This function removes the hidden attributes from the map infowindow and its contents
 function infoHider(){
     let hidden_div=document.getElementById("stationsTable")
     hidden_div.removeAttribute("hidden")
-    
-    
-    let hidden_cal=document.getElementById("timePicker")
-    hidden_cal.removeAttribute("hidden")
 }
 
 // This function receives the results of running the prediction model with the given variables
@@ -54,7 +52,9 @@ var calanderContents= tablediv.innerHTML;
 // async Function to return the predicted number of free bikes which is broken down into Poor,Good and Great availability
 async function predictSender(number,totalStands){
     // retrieves the inputted date (from the calander)
-    var date=document.getElementById("timePicker").value
+    var date=document.getElementById("datePicker").value;
+    var time=document.getElementById("timePicker").value;
+    
     let pred_number
     // This sends the date and the station number to the Flask app file to be used in the prediction
     $.ajax({
@@ -62,7 +62,7 @@ async function predictSender(number,totalStands){
         url: '/predGetter',
         contentType: 'application/json;charset=UTF-8',
         dataType: 'json',
-        data: JSON.stringify({number,date}),
+        data: JSON.stringify({number,date,time}),
     });
     
     // call the predictGetter function and wait for the result
@@ -172,20 +172,22 @@ function initMap() {
                                             "</h1><p>Available Bikes:" + station.AvailableBikes + 
                                             "</p><p>Available Stands:" + station.AvailableBikeStands + 
                                             "</p>"+
-                                            calanderContents
+                                            calanderContents+"<br>";
                 //calanderContents is the original contents of the stationTable (calander)
                 ;
                 //Creates the button which when pressed fetches the prediction
-                var btn= document.createElement("button")
+                var btn= document.createElement("button");
+                btn.setAttribute("id","predictBtn");
                 btn.innerHTML="Show me";
-                //btn.id=station.Number;
+                //btn.disabled= true;
                 // create predicted variable (got buggy if it wasnt defined outside of the addEventListener)
                 let predicted
                 btn.addEventListener("click",function(){
                     // sets the Onlick functionality of the button to Calling the predict sender function with the appropriate variables as argument
                     predicted = predictSender(station.Number,station.BikeStands)
                 });
-                document.getElementById("calander").appendChild(btn);
+                document.getElementById("buttonPlace").appendChild(btn);
+                
                 
                 // Creates the max and Min dates for the calander (Setting the seconds,milliseconds and Minnutes to 0 prevents the user from selecting those from the calander)
                 var date=new Date();
@@ -199,8 +201,8 @@ function initMap() {
                 now.setMinutes(0,0);
 
                 date.setDate(date.getDate()+7)
-                document.getElementById("timePicker").max=date.toISOString().split(".")[0];
-                document.getElementById("timePicker").min=now.toISOString().split(".")[0];                            
+                document.getElementById("datePicker").max=date.toISOString().split(".")[0];
+                document.getElementById("datePicker").min=now.toISOString().split(".")[0];                            
                 // Generate infoWindow with station Name and make it dissapear 
                 // when clicking on another marker
                 infoWindow.close();
@@ -219,6 +221,19 @@ function initMap() {
         console.log("OOPS!", err);
     });
 }
+
+/*
+document.getElementById("timePicker").addEventListener("change",buttonEnable(),false);
+
+function buttonEnable(){
+    console.log("JAVASCRIPT IS TRUE HUMAN SUFFERING")
+    var buttons =document.getElementsByTagName("button");
+    for (let i=0; i<buttons.length;i++){
+        buttons[i].disabled=false;
+    }
+
+    }
+*/
 
 // Get the element from the Dropdown menu and link it to the marker onClick event
 document.getElementById("dropdown").addEventListener("change", stationsDropDown);

--- a/dbikes/flaskapp/static/styles.css
+++ b/dbikes/flaskapp/static/styles.css
@@ -16,10 +16,7 @@ margin-right:auto;
     display: block;
 }
 
-/* This applys a white border to the elements of the stationsTable div, this helps with readability */
-#stationsTable > *{
-    border:1px solid rgba(255,255,255,1)
-}
+
 #stationsTable{
     /* position absolute allows the table to show up infront of the map */
     position:absolute;
@@ -33,6 +30,7 @@ margin-right:auto;
     font-family: Tahoma, sans-serif;
     /* overflow auto allows the background colour to apply to the nested calander divs */
     overflow: auto;
+    border:1px solid rgba(255,255,255,1)
 
 }
 

--- a/dbikes/flaskapp/templates/map.html
+++ b/dbikes/flaskapp/templates/map.html
@@ -40,8 +40,13 @@
             <div id="map"></div>
             <div hidden id="stationsTable">
                 <div id="calander">
-                    <label for="timePicker">See Predicted Availablity</label>
-                    <input type="datetime-local" id="timePicker" name="timePicker">
+                    <label for="datePicker">Choose a date</label>
+                    <input type="date" id="datePicker" name="timePicker">
+                    <br>
+                    <label for="timePicker">Select a time</label>
+                    <input type="time" id="timePicker" name="timePicker">
+                </div>
+                <div id="buttonPlace">
                 </div>
                 <div id="Message">
                 </div>
@@ -55,12 +60,12 @@
         <canvas id="weeklyChart"></canvas>
         </div>
     
-    </div>
-        <script src="{{ url_for('static', filename='js/map.js') }}"></script>
-        
+    </div>        
         <script
             src="https://maps.googleapis.com/maps/api/js?key={{apiKey}}&callback=initMap&libraries=&v=weekly"
         async
         ></script>
+            <script src="{{ url_for('static', filename='js/map.js') }}"></script>
+
 </body>
 </html>


### PR DESCRIPTION
- Changed the datetime-local to two seperate date and time inputs as datetime-local has poor support across browsers (IE & firefox for example
- Changed the predict sender and getter in the app.py to be able to read this new data form and use them appropriately in the prediction models
- changes the Stations table layout to reflect this new change
- the show me button is now in its own sepearate div (because javascript is a fussy baby)
- changed the borders on the info window to one solid white one around the whole perimeter and not a bunch of ones inbetween the nested divs 